### PR TITLE
add scalable E2E test infrastructure

### DIFF
--- a/tests/_run_all_tests.ts
+++ b/tests/_run_all_tests.ts
@@ -1,86 +1,370 @@
-// Stacks endpoints
-import { testX402ManualFlow as testDecodeClarity } from "./decode-clarity-hex.test";
-import { testX402ManualFlow as testConvertAddress } from "./convert-address-to-network.test";
-import { testX402ManualFlow as testGetBns } from "./get-bns-address.test";
-import { testX402ManualFlow as testValidateAddress } from "./validate-stacks-address.test";
+/**
+ * X402 Endpoint Test Runner
+ *
+ * Runs E2E payment tests against all registered endpoints.
+ *
+ * Usage:
+ *   bun run tests/_run_all_tests.ts                    # All endpoints, STX only
+ *   bun run tests/_run_all_tests.ts --all-tokens       # All endpoints, all tokens
+ *   bun run tests/_run_all_tests.ts --token=sBTC       # All endpoints, specific token
+ *   bun run tests/_run_all_tests.ts --category=stacks  # Single category
+ *   bun run tests/_run_all_tests.ts --filter=sha256    # Filter by name
+ *
+ * Environment:
+ *   X402_CLIENT_PK  - Testnet mnemonic for payments (required)
+ *   X402_NETWORK    - Network (default: testnet)
+ *   VERBOSE=1       - Enable verbose logging
+ */
 
-// AI endpoints
-import { testX402ManualFlow as testDadJoke } from "./dad-joke.test";
-import { testX402ManualFlow as testTts } from "./tts.test";
-import { testX402ManualFlow as testSummarize } from "./summarize.test";
-import { testX402ManualFlow as testImageDescribe } from "./image-describe.test";
-import { testX402ManualFlow as testGenerateImage } from "./generate-image.test";
+import type { TokenType, NetworkType } from "x402-stacks";
+import { X402PaymentClient } from "x402-stacks";
+import { deriveChildAccount } from "../src/utils/wallet";
+import { ENDPOINT_REGISTRY, ENDPOINT_CATEGORIES, ENDPOINT_COUNTS } from "./endpoint-registry";
+import type { TestConfig } from "./_test_generator";
+import {
+  COLORS,
+  X402_CLIENT_PK,
+  X402_NETWORK,
+  X402_WORKER_URL,
+  createTestLogger,
+} from "./_shared_utils";
 
-import { COLORS, TEST_TOKENS } from "./_shared_utils";
+// =============================================================================
+// Configuration
+// =============================================================================
 
-async function runAllTests() {
-  const verbose = process.env.VERBOSE === "1";
-  const clearScreen = process.env.CLEAR_SCREEN === "1";
-
-  if (clearScreen) console.clear();
-
-  console.log(`${COLORS.bright}🚀 Starting all X402 tests...${COLORS.reset}\n`);
-
-  const tests = [
-    // Stacks endpoints
-    { name: "decode-clarity-hex", fn: testDecodeClarity },
-    { name: "convert-address-to-network", fn: testConvertAddress },
-    { name: "get-bns-address", fn: testGetBns },
-    { name: "validate-stacks-address", fn: testValidateAddress },
-    // AI endpoints
-    { name: "dad-joke", fn: testDadJoke },
-    { name: "tts", fn: testTts },
-    { name: "summarize", fn: testSummarize },
-    { name: "image-describe", fn: testImageDescribe },
-    { name: "generate-image", fn: testGenerateImage },
-  ];
-
-  interface TokenStats {
-    success: number;
-    total: number;
-  }
-  const tokenStats: Record<string, TokenStats> = {};
-
-  for (const t of tests) {
-    console.log(`${COLORS.bright}━${"━".repeat(60)}━${COLORS.reset}`);
-    console.log(`${COLORS.bright}🔄 Running ${COLORS.yellow}${t.name}${COLORS.reset}`);
-    console.log(`${COLORS.bright}━${"━".repeat(60)}━${COLORS.reset}\n`);
-
-    try {
-      const result = await t.fn(verbose) as { tokenResults: Record<string, boolean> };
-      for (const [token, passed] of Object.entries(result.tokenResults)) {
-        if (!tokenStats[token]) {
-          tokenStats[token] = { success: 0, total: 0 };
-        }
-        tokenStats[token]!.total++;
-        if (passed) {
-          tokenStats[token]!.success++;
-        }
-      }
-    } catch (e) {
-      console.log(`${COLORS.bright}${COLORS.red}💥 ${t.name.toUpperCase()} CRASHED:${COLORS.reset}`);
-      console.error(e);
-      for (const token of TEST_TOKENS) {
-        if (!tokenStats[token]) {
-          tokenStats[token] = { success: 0, total: 0 };
-        }
-        tokenStats[token]!.total++;
-      }
-    }
-    console.log();
-  }
-
-  const globalSuccess = Object.values(tokenStats).reduce((sum, s) => sum + s.success, 0);
-  const globalTotal = Object.values(tokenStats).reduce((sum, s) => sum + s.total, 0);
-  const passRate = globalTotal ? ((globalSuccess / globalTotal) * 100).toFixed(1) : "0.0";
-
-  const summaryParts: string[] = [];
-  for (const [token, stats] of Object.entries(tokenStats)) {
-    const tokenRate = ((stats.success / stats.total) * 100).toFixed(1);
-    summaryParts.push(`${token}:${stats.success}/${stats.total} (${tokenRate}%)`);
-  }
-
-  console.log(`${COLORS.bright}🎉 FINAL SUMMARY: ${summaryParts.join(", ")} | Total: ${globalSuccess}/${globalTotal} (${passRate}%)${COLORS.reset}`);
+interface RunConfig {
+  tokens: TokenType[];
+  category: string | null;
+  filter: string | null;
+  maxConsecutiveFailures: number;
+  verbose: boolean;
 }
 
-runAllTests().catch(console.error);
+function parseArgs(): RunConfig {
+  const args = process.argv.slice(2);
+  const config: RunConfig = {
+    tokens: ["STX"], // Default to single token
+    category: null,
+    filter: null,
+    maxConsecutiveFailures: 5,
+    verbose: process.env.VERBOSE === "1",
+  };
+
+  for (const arg of args) {
+    if (arg === "--all-tokens") {
+      config.tokens = ["STX", "sBTC", "USDCx"];
+    } else if (arg.startsWith("--token=")) {
+      const token = arg.split("=")[1].toUpperCase();
+      if (["STX", "SBTC", "USDCX"].includes(token)) {
+        config.tokens = [token === "SBTC" ? "sBTC" : token === "USDCX" ? "USDCx" : token] as TokenType[];
+      }
+    } else if (arg.startsWith("--category=")) {
+      config.category = arg.split("=")[1].toLowerCase();
+    } else if (arg.startsWith("--filter=")) {
+      config.filter = arg.split("=")[1].toLowerCase();
+    } else if (arg.startsWith("--max-failures=")) {
+      config.maxConsecutiveFailures = parseInt(arg.split("=")[1], 10);
+    } else if (arg === "--verbose" || arg === "-v") {
+      config.verbose = true;
+    }
+  }
+
+  return config;
+}
+
+// =============================================================================
+// X402 Payment Flow
+// =============================================================================
+
+interface X402PaymentRequired {
+  maxAmountRequired: string;
+  resource: string;
+  payTo: string;
+  network: "mainnet" | "testnet";
+  nonce: string;
+  expiresAt: string;
+  tokenType: TokenType;
+}
+
+async function testEndpointWithToken(
+  config: TestConfig,
+  tokenType: TokenType,
+  x402Client: X402PaymentClient,
+  verbose: boolean
+): Promise<{ passed: boolean; error?: string }> {
+  const logger = createTestLogger(config.name, verbose);
+  const endpoint = config.endpoint.includes("?")
+    ? `${config.endpoint}&tokenType=${tokenType}`
+    : `${config.endpoint}?tokenType=${tokenType}`;
+  const fullUrl = `${X402_WORKER_URL}${endpoint}`;
+
+  try {
+    // Step 1: Initial request (expect 402)
+    logger.debug("1. Initial request...");
+
+    const initialRes = await fetch(fullUrl, {
+      method: config.method,
+      headers: {
+        ...(config.body ? { "Content-Type": "application/json" } : {}),
+        ...config.headers,
+      },
+      body: config.body ? JSON.stringify(config.body) : undefined,
+    });
+
+    if (initialRes.status !== 402) {
+      const text = await initialRes.text();
+      return { passed: false, error: `Expected 402, got ${initialRes.status}: ${text.slice(0, 100)}` };
+    }
+
+    const paymentReq: X402PaymentRequired = await initialRes.json();
+
+    if (paymentReq.tokenType !== tokenType) {
+      return { passed: false, error: `Token mismatch: expected ${tokenType}, got ${paymentReq.tokenType}` };
+    }
+
+    // Step 2: Sign payment
+    logger.debug("2. Signing payment...");
+    const signResult = await x402Client.signPayment(paymentReq);
+
+    // Step 3: Retry with X-PAYMENT header
+    logger.debug("3. Retry with payment...");
+
+    const retryRes = await fetch(fullUrl, {
+      method: config.method,
+      headers: {
+        ...(config.body ? { "Content-Type": "application/json" } : {}),
+        ...config.headers,
+        "X-PAYMENT": signResult.signedTransaction,
+        "X-PAYMENT-TOKEN-TYPE": tokenType,
+      },
+      body: config.body ? JSON.stringify(config.body) : undefined,
+    });
+
+    if (retryRes.status !== 200) {
+      const errText = await retryRes.text();
+      return { passed: false, error: `Retry failed (${retryRes.status}): ${errText.slice(0, 100)}` };
+    }
+
+    // Step 4: Validate response
+    const contentType = retryRes.headers.get("content-type") || "";
+    const expectedContentType = config.expectedContentType || "application/json";
+
+    // For non-JSON responses, just check content-type
+    if (!contentType.includes("application/json")) {
+      if (contentType.includes(expectedContentType.split("/")[0])) {
+        return { passed: true };
+      }
+      return { passed: false, error: `Wrong content-type: expected ${expectedContentType}, got ${contentType}` };
+    }
+
+    // For JSON responses, validate the data
+    const data = await retryRes.json();
+    logger.debug("Response", data);
+
+    if (config.validateResponse(data, tokenType)) {
+      return { passed: true };
+    }
+
+    return { passed: false, error: "Response validation failed" };
+  } catch (error) {
+    return { passed: false, error: String(error) };
+  }
+}
+
+// =============================================================================
+// Test Runner
+// =============================================================================
+
+interface TestResult {
+  name: string;
+  tokenResults: Record<TokenType, { passed: boolean; error?: string }>;
+}
+
+interface RunStats {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  byToken: Record<TokenType, { passed: number; failed: number }>;
+  failedTests: Array<{ name: string; token: TokenType; error: string }>;
+}
+
+async function runTests(runConfig: RunConfig): Promise<RunStats> {
+  if (!X402_CLIENT_PK) {
+    throw new Error("Set X402_CLIENT_PK env var with testnet mnemonic");
+  }
+
+  // Initialize wallet
+  const { address, key } = await deriveChildAccount(
+    X402_NETWORK as NetworkType,
+    X402_CLIENT_PK,
+    0
+  );
+
+  const x402Client = new X402PaymentClient({
+    network: X402_NETWORK as NetworkType,
+    privateKey: key,
+  });
+
+  // Select endpoints to test
+  let endpoints: TestConfig[] = runConfig.category
+    ? ENDPOINT_CATEGORIES[runConfig.category] || []
+    : ENDPOINT_REGISTRY;
+
+  if (runConfig.filter) {
+    endpoints = endpoints.filter((e) =>
+      e.name.toLowerCase().includes(runConfig.filter!)
+    );
+  }
+
+  // Initialize stats
+  const stats: RunStats = {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    byToken: {} as Record<TokenType, { passed: number; failed: number }>,
+    failedTests: [],
+  };
+
+  for (const token of runConfig.tokens) {
+    stats.byToken[token] = { passed: 0, failed: 0 };
+  }
+
+  // Print header
+  console.log(`\n${COLORS.bright}${"═".repeat(70)}${COLORS.reset}`);
+  console.log(`${COLORS.bright}  X402 ENDPOINT TEST RUNNER${COLORS.reset}`);
+  console.log(`${COLORS.bright}${"═".repeat(70)}${COLORS.reset}`);
+  console.log(`  Wallet:     ${address}`);
+  console.log(`  Server:     ${X402_WORKER_URL}`);
+  console.log(`  Endpoints:  ${endpoints.length}`);
+  console.log(`  Tokens:     ${runConfig.tokens.join(", ")}`);
+  console.log(`  Total runs: ${endpoints.length * runConfig.tokens.length}`);
+  console.log(`${COLORS.bright}${"═".repeat(70)}${COLORS.reset}\n`);
+
+  // Track consecutive failures
+  let consecutiveFailures = 0;
+
+  // Run tests
+  for (let i = 0; i < endpoints.length; i++) {
+    const endpoint = endpoints[i];
+
+    // Check bail-out condition
+    if (consecutiveFailures >= runConfig.maxConsecutiveFailures) {
+      console.log(
+        `\n${COLORS.red}${COLORS.bright}BAIL OUT: ${consecutiveFailures} consecutive failures${COLORS.reset}`
+      );
+      stats.skipped = (endpoints.length - i) * runConfig.tokens.length;
+      break;
+    }
+
+    const progress = `[${i + 1}/${endpoints.length}]`;
+    console.log(
+      `${COLORS.bright}${progress}${COLORS.reset} ${COLORS.cyan}${endpoint.name}${COLORS.reset}`
+    );
+
+    let allPassed = true;
+    const tokenResults: string[] = [];
+
+    for (const token of runConfig.tokens) {
+      stats.total++;
+
+      const result = await testEndpointWithToken(
+        endpoint,
+        token,
+        x402Client,
+        runConfig.verbose
+      );
+
+      if (result.passed) {
+        stats.passed++;
+        stats.byToken[token].passed++;
+        tokenResults.push(`${COLORS.green}${token}:✓${COLORS.reset}`);
+      } else {
+        stats.failed++;
+        stats.byToken[token].failed++;
+        allPassed = false;
+        tokenResults.push(`${COLORS.red}${token}:✗${COLORS.reset}`);
+        stats.failedTests.push({
+          name: endpoint.name,
+          token,
+          error: result.error || "Unknown error",
+        });
+      }
+    }
+
+    // Print token results
+    console.log(`    ${tokenResults.join("  ")}`);
+
+    // Update consecutive failure count
+    if (allPassed) {
+      consecutiveFailures = 0;
+    } else {
+      consecutiveFailures++;
+    }
+
+    // Brief delay between endpoints to avoid rate limiting
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  return stats;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main() {
+  const config = parseArgs();
+
+  console.clear();
+
+  try {
+    const stats = await runTests(config);
+
+    // Print summary
+    console.log(`\n${COLORS.bright}${"═".repeat(70)}${COLORS.reset}`);
+    console.log(`${COLORS.bright}  SUMMARY${COLORS.reset}`);
+    console.log(`${COLORS.bright}${"═".repeat(70)}${COLORS.reset}`);
+
+    const passRate = stats.total > 0 ? ((stats.passed / stats.total) * 100).toFixed(1) : "0.0";
+    const color = stats.failed === 0 ? COLORS.green : stats.passed > stats.failed ? COLORS.yellow : COLORS.red;
+
+    console.log(`  ${color}${COLORS.bright}${stats.passed}/${stats.total} passed (${passRate}%)${COLORS.reset}`);
+
+    if (stats.skipped > 0) {
+      console.log(`  ${COLORS.yellow}${stats.skipped} skipped (bail-out)${COLORS.reset}`);
+    }
+
+    // Per-token breakdown
+    console.log(`\n  By Token:`);
+    for (const [token, tokenStats] of Object.entries(stats.byToken)) {
+      const tokenTotal = tokenStats.passed + tokenStats.failed;
+      const tokenRate = tokenTotal > 0 ? ((tokenStats.passed / tokenTotal) * 100).toFixed(0) : "0";
+      const tokenColor = tokenStats.failed === 0 ? COLORS.green : COLORS.yellow;
+      console.log(
+        `    ${tokenColor}${token}: ${tokenStats.passed}/${tokenTotal} (${tokenRate}%)${COLORS.reset}`
+      );
+    }
+
+    // Failed tests detail
+    if (stats.failedTests.length > 0) {
+      console.log(`\n  ${COLORS.red}Failed Tests:${COLORS.reset}`);
+      for (const fail of stats.failedTests) {
+        console.log(`    ${COLORS.red}✗${COLORS.reset} ${fail.name} [${fail.token}]`);
+        console.log(`      ${COLORS.gray}${fail.error}${COLORS.reset}`);
+      }
+    }
+
+    console.log(`\n${COLORS.bright}${"═".repeat(70)}${COLORS.reset}\n`);
+
+    // Exit with error code if any failures
+    process.exit(stats.failed > 0 ? 1 : 0);
+  } catch (error) {
+    console.error(`\n${COLORS.red}${COLORS.bright}FATAL ERROR:${COLORS.reset}`, error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/_shared_utils.ts
+++ b/tests/_shared_utils.ts
@@ -13,8 +13,8 @@ export const COLORS = {
 export const X402_CLIENT_PK = process.env.X402_CLIENT_PK;
 export const X402_NETWORK = (process.env.X402_NETWORK || "testnet") as NetworkType;
 
-// "https://stx402.chaos.workers.dev";
-export const X402_WORKER_URL = "http://localhost:8787";
+// Override with X402_WORKER_URL env var for production testing
+export const X402_WORKER_URL = process.env.X402_WORKER_URL || "http://localhost:8787";
 
 export const TEST_TOKENS: TokenType[] = ["STX", "sBTC", "USDCx"];
 

--- a/tests/endpoint-registry.ts
+++ b/tests/endpoint-registry.ts
@@ -1,0 +1,990 @@
+/**
+ * Endpoint Registry for X402 Tests
+ *
+ * Central configuration for all paid endpoints with test data and validation.
+ * Used by _run_all_tests.ts for comprehensive E2E payment testing.
+ */
+
+import type { TestConfig } from "./_test_generator";
+import type { TokenType } from "x402-stacks";
+
+// =============================================================================
+// Test Fixtures - Reusable test data
+// =============================================================================
+
+const FIXTURES = {
+  // Stacks addresses
+  mainnetAddress: "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9",
+  testnetAddress: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+  bnsAddress: "SP1JTCR202ECC6333N7ZXD7MK7E3ZTEEE1MJ73C60", // Has BNS name
+
+  // Contracts
+  mainnetContract: "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait",
+  testnetContract: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-trait",
+
+  // Sample text
+  shortText: "Hello, World!",
+  longText: "The quick brown fox jumps over the lazy dog.",
+  utf8Text: "Hello 世界 🌍",
+
+  // Sample data
+  simpleJson: { name: "test", value: 42 },
+  simpleCsv: "name,age\nAlice,30\nBob,25",
+
+  // Hashes (precomputed for "test")
+  sha256OfTest: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  base64OfTest: "dGVzdA==",
+};
+
+// =============================================================================
+// Validation Helpers
+// =============================================================================
+
+type DataWithToken = { tokenType: TokenType };
+
+const hasTokenType = (data: unknown, tokenType: TokenType): boolean => {
+  const d = data as DataWithToken;
+  return d.tokenType === tokenType;
+};
+
+const hasField = (data: unknown, field: string): boolean => {
+  return typeof data === "object" && data !== null && field in data;
+};
+
+const hasFields = (data: unknown, fields: string[]): boolean => {
+  return fields.every((f) => hasField(data, f));
+};
+
+// =============================================================================
+// STACKS ENDPOINTS (15)
+// =============================================================================
+
+const stacksEndpoints: TestConfig[] = [
+  {
+    name: "get-bns-name",
+    endpoint: `/api/stacks/get-bns-name/${FIXTURES.bnsAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "name") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "validate-address",
+    endpoint: `/api/stacks/validate-address/${FIXTURES.mainnetAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["valid", "version", "network"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "convert-address",
+    endpoint: `/api/stacks/convert-address/${FIXTURES.mainnetAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["mainnet", "testnet"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "decode-clarity-hex",
+    endpoint: "/api/stacks/decode-clarity-hex",
+    method: "POST",
+    body: { hex: "0x0100000000000000000000000000000001" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "decoded") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "contract-source",
+    endpoint: `/api/stacks/contract-source/${FIXTURES.mainnetContract}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["source", "hash", "contractId"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "contract-abi",
+    endpoint: `/api/stacks/contract-abi/${FIXTURES.mainnetContract}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "abi") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "to-consensus-buff",
+    endpoint: "/api/stacks/to-consensus-buff",
+    method: "POST",
+    body: { value: { type: "uint", value: "1" } },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "hex") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "from-consensus-buff",
+    endpoint: "/api/stacks/from-consensus-buff",
+    method: "POST",
+    body: { hex: "0x0100000000000000000000000000000001" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "value") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "decode-tx",
+    endpoint: "/api/stacks/decode-tx",
+    method: "POST",
+    body: {
+      hex: "0x00000000010400e6c05355e0c990ffad19a5e9bda394a9c500342900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003020000000000051ae6c05355e0c990ffad19a5e9bda394a9c5003429000000000000271000000000000000000000000000000000000000000000000000000000000000000000",
+    },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "decoded") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "call-readonly",
+    endpoint: "/api/stacks/call-readonly",
+    method: "POST",
+    body: {
+      contractAddress: "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9",
+      contractName: "nft-trait",
+      functionName: "get-last-token-id",
+      functionArgs: [],
+    },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "result") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "stx-balance",
+    endpoint: `/api/stacks/stx-balance/${FIXTURES.mainnetAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["balance", "balanceFormatted"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "block-height",
+    endpoint: "/api/stacks/block-height",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["stacks", "bitcoin"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "ft-balance",
+    endpoint: `/api/stacks/ft-balance/${FIXTURES.mainnetAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "balances") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "nft-holdings",
+    endpoint: `/api/stacks/nft-holdings/${FIXTURES.mainnetAddress}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "nfts") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "tx-status",
+    endpoint: "/api/stacks/tx-status/0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "status") && hasTokenType(data, tokenType),
+  },
+];
+
+// =============================================================================
+// AI ENDPOINTS (13)
+// =============================================================================
+
+const aiEndpoints: TestConfig[] = [
+  {
+    name: "dad-joke",
+    endpoint: "/api/ai/dad-joke",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "joke") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "summarize",
+    endpoint: "/api/ai/summarize",
+    method: "POST",
+    body: { text: FIXTURES.longText, maxLength: 50 },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "summary") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "image-describe",
+    endpoint: "/api/ai/image-describe",
+    method: "POST",
+    body: { imageUrl: "https://picsum.photos/200" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "description") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "tts",
+    endpoint: "/api/ai/tts",
+    method: "POST",
+    body: { text: "Hello world" },
+    expectedContentType: "audio",
+    validateResponse: () => true, // Audio content validated by content-type
+  },
+  {
+    name: "generate-image",
+    endpoint: "/api/ai/generate-image",
+    method: "POST",
+    body: { prompt: "a simple red circle" },
+    expectedContentType: "image",
+    validateResponse: () => true, // Image content validated by content-type
+  },
+  {
+    name: "explain-contract",
+    endpoint: `/api/ai/explain-contract/${FIXTURES.mainnetContract}`,
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "explanation") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "translate",
+    endpoint: "/api/ai/translate",
+    method: "POST",
+    body: { text: "Hello world", targetLanguage: "es" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "translation") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "sentiment",
+    endpoint: "/api/ai/sentiment",
+    method: "POST",
+    body: { text: "I love this product! It's amazing!" },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["sentiment", "score"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "keywords",
+    endpoint: "/api/ai/keywords",
+    method: "POST",
+    body: { text: FIXTURES.longText },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "keywords") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "language-detect",
+    endpoint: "/api/ai/language-detect",
+    method: "POST",
+    body: { text: "Bonjour le monde" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "language") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "paraphrase",
+    endpoint: "/api/ai/paraphrase",
+    method: "POST",
+    body: { text: FIXTURES.longText },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "paraphrased") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "grammar-check",
+    endpoint: "/api/ai/grammar-check",
+    method: "POST",
+    body: { text: "He go to the store yesterday." },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "corrected") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "question-answer",
+    endpoint: "/api/ai/question-answer",
+    method: "POST",
+    body: { context: "The sky is blue.", question: "What color is the sky?" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "answer") && hasTokenType(data, tokenType),
+  },
+];
+
+// =============================================================================
+// TEXT ENDPOINTS (25)
+// =============================================================================
+
+const textEndpoints: TestConfig[] = [
+  {
+    name: "base64-encode",
+    endpoint: "/api/text/base64-encode",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { encoded: string; tokenType: TokenType };
+      return d.encoded === FIXTURES.base64OfTest && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "base64-decode",
+    endpoint: "/api/text/base64-decode",
+    method: "POST",
+    body: { encoded: FIXTURES.base64OfTest },
+    validateResponse: (data, tokenType) => {
+      const d = data as { text: string; tokenType: TokenType };
+      return d.text === "test" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "sha256",
+    endpoint: "/api/text/sha256",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { hash: string; tokenType: TokenType };
+      return d.hash === FIXTURES.sha256OfTest && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "sha512",
+    endpoint: "/api/text/sha512",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hash", "algorithm"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "keccak256",
+    endpoint: "/api/text/keccak256",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hash", "algorithm"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "hash160",
+    endpoint: "/api/text/hash160",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hash", "algorithm"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "url-encode",
+    endpoint: "/api/text/url-encode",
+    method: "POST",
+    body: { text: "hello world" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { encoded: string; tokenType: TokenType };
+      return d.encoded === "hello%20world" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "url-decode",
+    endpoint: "/api/text/url-decode",
+    method: "POST",
+    body: { encoded: "hello%20world" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { text: string; tokenType: TokenType };
+      return d.text === "hello world" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "jwt-decode",
+    endpoint: "/api/text/jwt-decode",
+    method: "POST",
+    body: {
+      jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["header", "payload"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "hmac",
+    endpoint: "/api/text/hmac",
+    method: "POST",
+    body: { text: "message", key: "secret" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "hmac") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "html-encode",
+    endpoint: "/api/text/html-encode",
+    method: "POST",
+    body: { text: "<div>Hello</div>" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { encoded: string; tokenType: TokenType };
+      return d.encoded.includes("&lt;") && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "html-decode",
+    endpoint: "/api/text/html-decode",
+    method: "POST",
+    body: { encoded: "&lt;div&gt;Hello&lt;/div&gt;" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { text: string; tokenType: TokenType };
+      return d.text === "<div>Hello</div>" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "hex-encode",
+    endpoint: "/api/text/hex-encode",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { hex: string; tokenType: TokenType };
+      return d.hex === "74657374" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "hex-decode",
+    endpoint: "/api/text/hex-decode",
+    method: "POST",
+    body: { hex: "74657374" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { text: string; tokenType: TokenType };
+      return d.text === "test" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "case-convert",
+    endpoint: "/api/text/case-convert",
+    method: "POST",
+    body: { text: "hello world", case: "upper" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { result: string; tokenType: TokenType };
+      return d.result === "HELLO WORLD" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "slug",
+    endpoint: "/api/text/slug",
+    method: "POST",
+    body: { text: "Hello World!" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { slug: string; tokenType: TokenType };
+      return d.slug === "hello-world" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "word-count",
+    endpoint: "/api/text/word-count",
+    method: "POST",
+    body: { text: "Hello world test" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { words: number; tokenType: TokenType };
+      return d.words === 3 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "reverse",
+    endpoint: "/api/text/reverse",
+    method: "POST",
+    body: { text: "hello" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { reversed: string; tokenType: TokenType };
+      return d.reversed === "olleh" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "truncate",
+    endpoint: "/api/text/truncate",
+    method: "POST",
+    body: { text: "Hello World!", maxLength: 5 },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "truncated") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "regex-test",
+    endpoint: "/api/text/regex-test",
+    method: "POST",
+    body: { text: "test@example.com", pattern: "^[\\w.-]+@[\\w.-]+\\.\\w+$" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { matches: boolean; tokenType: TokenType };
+      return d.matches === true && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "rot13",
+    endpoint: "/api/text/rot13",
+    method: "POST",
+    body: { text: "hello" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { result: string; tokenType: TokenType };
+      return d.result === "uryyb" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "lorem-ipsum",
+    endpoint: "/api/text/lorem-ipsum",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "text") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "validate-url",
+    endpoint: "/api/text/validate-url?url=https://example.com",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { valid: boolean; tokenType: TokenType };
+      return d.valid === true && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "diff",
+    endpoint: "/api/text/diff",
+    method: "POST",
+    body: { original: "hello world", modified: "hello there" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "diff") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "unicode-info",
+    endpoint: "/api/text/unicode-info?char=A",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["codePoint", "name"]) && hasTokenType(data, tokenType),
+  },
+];
+
+// =============================================================================
+// DATA ENDPOINTS (8)
+// =============================================================================
+
+const dataEndpoints: TestConfig[] = [
+  {
+    name: "csv-to-json",
+    endpoint: "/api/data/csv-to-json",
+    method: "POST",
+    body: { csv: FIXTURES.simpleCsv },
+    validateResponse: (data, tokenType) => {
+      const d = data as { data: unknown[]; rows: number; tokenType: TokenType };
+      return d.rows === 2 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "json-to-csv",
+    endpoint: "/api/data/json-to-csv",
+    method: "POST",
+    body: { data: [{ name: "Alice", age: 30 }] },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "csv") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "json-format",
+    endpoint: "/api/data/json-format",
+    method: "POST",
+    body: { json: '{"a":1}' },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "formatted") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "json-minify",
+    endpoint: "/api/data/json-minify",
+    method: "POST",
+    body: { json: '{\n  "a": 1\n}' },
+    validateResponse: (data, tokenType) => {
+      const d = data as { minified: string; tokenType: TokenType };
+      return d.minified === '{"a":1}' && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "json-validate",
+    endpoint: "/api/data/json-validate",
+    method: "POST",
+    body: { json: '{"valid": true}' },
+    validateResponse: (data, tokenType) => {
+      const d = data as { valid: boolean; tokenType: TokenType };
+      return d.valid === true && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "json-path",
+    endpoint: "/api/data/json-path",
+    method: "POST",
+    body: { json: { a: { b: 1 } }, path: "$.a.b" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "result") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "json-flatten",
+    endpoint: "/api/data/json-flatten",
+    method: "POST",
+    body: { json: { a: { b: 1 } } },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "flattened") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "json-merge",
+    endpoint: "/api/data/json-merge",
+    method: "POST",
+    body: { objects: [{ a: 1 }, { b: 2 }] },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "merged") && hasTokenType(data, tokenType),
+  },
+];
+
+// =============================================================================
+// CRYPTO ENDPOINTS (2)
+// =============================================================================
+
+const cryptoEndpoints: TestConfig[] = [
+  {
+    name: "ripemd160",
+    endpoint: "/api/crypto/ripemd160",
+    method: "POST",
+    body: { text: "test" },
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hash", "algorithm"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "random-bytes",
+    endpoint: "/api/crypto/random-bytes?length=16",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { hex: string; tokenType: TokenType };
+      return d.hex.length === 32 && d.tokenType === tokenType; // 16 bytes = 32 hex chars
+    },
+  },
+];
+
+// =============================================================================
+// RANDOM ENDPOINTS (7)
+// =============================================================================
+
+const randomEndpoints: TestConfig[] = [
+  {
+    name: "uuid",
+    endpoint: "/api/random/uuid",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { uuid: string; tokenType: TokenType };
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      return uuidRegex.test(d.uuid) && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "number",
+    endpoint: "/api/random/number?min=1&max=100",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { number: number; tokenType: TokenType };
+      return d.number >= 1 && d.number <= 100 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "string",
+    endpoint: "/api/random/string?length=10",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { string: string; tokenType: TokenType };
+      return d.string.length === 10 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "password",
+    endpoint: "/api/random/password?length=16",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { password: string; tokenType: TokenType };
+      return d.password.length === 16 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "color",
+    endpoint: "/api/random/color",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hex", "rgb"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "dice",
+    endpoint: "/api/random/dice?count=2&sides=6",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { rolls: number[]; tokenType: TokenType };
+      return d.rolls.length === 2 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "shuffle",
+    endpoint: "/api/random/shuffle",
+    method: "POST",
+    body: { items: [1, 2, 3, 4, 5] },
+    validateResponse: (data, tokenType) => {
+      const d = data as { shuffled: number[]; tokenType: TokenType };
+      return d.shuffled.length === 5 && d.tokenType === tokenType;
+    },
+  },
+];
+
+// =============================================================================
+// MATH ENDPOINTS (6)
+// =============================================================================
+
+const mathEndpoints: TestConfig[] = [
+  {
+    name: "calculate",
+    endpoint: "/api/math/calculate",
+    method: "POST",
+    body: { expression: "2 + 2" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { result: number; tokenType: TokenType };
+      return d.result === 4 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "percentage",
+    endpoint: "/api/math/percentage",
+    method: "POST",
+    body: { value: 50, total: 200 },
+    validateResponse: (data, tokenType) => {
+      const d = data as { percentage: number; tokenType: TokenType };
+      return d.percentage === 25 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "statistics",
+    endpoint: "/api/math/statistics",
+    method: "POST",
+    body: { numbers: [1, 2, 3, 4, 5] },
+    validateResponse: (data, tokenType) => {
+      const d = data as { mean: number; tokenType: TokenType };
+      return d.mean === 3 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "prime-check",
+    endpoint: "/api/math/prime-check?number=17",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { isPrime: boolean; tokenType: TokenType };
+      return d.isPrime === true && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "gcd-lcm",
+    endpoint: "/api/math/gcd-lcm",
+    method: "POST",
+    body: { a: 12, b: 18 },
+    validateResponse: (data, tokenType) => {
+      const d = data as { gcd: number; lcm: number; tokenType: TokenType };
+      return d.gcd === 6 && d.lcm === 36 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "factorial",
+    endpoint: "/api/math/factorial?n=5",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { result: number; tokenType: TokenType };
+      return d.result === 120 && d.tokenType === tokenType;
+    },
+  },
+];
+
+// =============================================================================
+// UTILITY ENDPOINTS (22)
+// =============================================================================
+
+const utilEndpoints: TestConfig[] = [
+  {
+    name: "timestamp",
+    endpoint: "/api/util/timestamp",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["unix", "iso", "utc"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "dns-lookup",
+    endpoint: "/api/util/dns-lookup?domain=google.com",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "addresses") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "ip-info",
+    endpoint: "/api/util/ip-info",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "ip") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "qr-generate",
+    endpoint: "/api/util/qr-generate",
+    method: "POST",
+    body: { data: "https://example.com", format: "base64" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "base64") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "timestamp-convert",
+    endpoint: "/api/util/timestamp-convert?timestamp=1704067200",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["iso", "utc"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "date-diff",
+    endpoint: "/api/util/date-diff?date1=2024-01-01&date2=2024-01-10",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { days: number; tokenType: TokenType };
+      return d.days === 9 && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "date-add",
+    endpoint: "/api/util/date-add",
+    method: "POST",
+    body: { date: "2024-01-01", add: { days: 5 } },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "result") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "cron-parse",
+    endpoint: "/api/util/cron-parse?cron=0%209%20*%20*%20*",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "description") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "user-agent-parse",
+    endpoint: "/api/util/user-agent-parse?ua=Mozilla/5.0%20Chrome/120.0.0.0",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "browser") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "url-parse",
+    endpoint: "/api/util/url-parse?url=https://example.com/path?q=1",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["protocol", "host", "pathname"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "color-convert",
+    endpoint: "/api/util/color-convert?color=%23ff0000",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasFields(data, ["hex", "rgb", "hsl"]) && hasTokenType(data, tokenType),
+  },
+  {
+    name: "markdown-to-html",
+    endpoint: "/api/util/markdown-to-html",
+    method: "POST",
+    body: { markdown: "# Hello\n\nWorld" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { html: string; tokenType: TokenType };
+      return d.html.includes("<h1>") && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "http-status",
+    endpoint: "/api/util/http-status?code=200",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { message: string; tokenType: TokenType };
+      return d.message === "OK" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "validate-email",
+    endpoint: "/api/util/validate-email?email=test@example.com",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { valid: boolean; tokenType: TokenType };
+      return d.valid === true && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "url-build",
+    endpoint: "/api/util/url-build",
+    method: "POST",
+    body: { base: "https://example.com", path: "/api", params: { q: "test" } },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "url") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "html-to-text",
+    endpoint: "/api/util/html-to-text",
+    method: "POST",
+    body: { html: "<p>Hello <b>World</b></p>" },
+    validateResponse: (data, tokenType) =>
+      hasField(data, "text") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "base64-image",
+    endpoint: "/api/util/base64-image?url=https://picsum.photos/50",
+    method: "GET",
+    validateResponse: (data, tokenType) =>
+      hasField(data, "base64") && hasTokenType(data, tokenType),
+  },
+  {
+    name: "bytes-format",
+    endpoint: "/api/util/bytes-format?bytes=1048576",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { formatted: string; tokenType: TokenType };
+      return d.formatted === "1 MB" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "slugify",
+    endpoint: "/api/util/slugify",
+    method: "POST",
+    body: { text: "Hello World!" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { slug: string; tokenType: TokenType };
+      return d.slug === "hello-world" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "mime-type",
+    endpoint: "/api/util/mime-type?filename=test.json",
+    method: "GET",
+    validateResponse: (data, tokenType) => {
+      const d = data as { mimeType: string; tokenType: TokenType };
+      return d.mimeType === "application/json" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "regex-escape",
+    endpoint: "/api/util/regex-escape",
+    method: "POST",
+    body: { text: "hello.world" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { escaped: string; tokenType: TokenType };
+      return d.escaped === "hello\\.world" && d.tokenType === tokenType;
+    },
+  },
+  {
+    name: "string-distance",
+    endpoint: "/api/util/string-distance",
+    method: "POST",
+    body: { string1: "kitten", string2: "sitting" },
+    validateResponse: (data, tokenType) => {
+      const d = data as { levenshtein: number; tokenType: TokenType };
+      return d.levenshtein === 3 && d.tokenType === tokenType;
+    },
+  },
+];
+
+// =============================================================================
+// EXPORT COMBINED REGISTRY
+// =============================================================================
+
+export const ENDPOINT_REGISTRY: TestConfig[] = [
+  ...stacksEndpoints,
+  ...aiEndpoints,
+  ...textEndpoints,
+  ...dataEndpoints,
+  ...cryptoEndpoints,
+  ...randomEndpoints,
+  ...mathEndpoints,
+  ...utilEndpoints,
+];
+
+// Category mapping for filtered runs
+export const ENDPOINT_CATEGORIES: Record<string, TestConfig[]> = {
+  stacks: stacksEndpoints,
+  ai: aiEndpoints,
+  text: textEndpoints,
+  data: dataEndpoints,
+  crypto: cryptoEndpoints,
+  random: randomEndpoints,
+  math: mathEndpoints,
+  util: utilEndpoints,
+};
+
+// Export counts for verification
+export const ENDPOINT_COUNTS = {
+  total: ENDPOINT_REGISTRY.length,
+  stacks: stacksEndpoints.length,
+  ai: aiEndpoints.length,
+  text: textEndpoints.length,
+  data: dataEndpoints.length,
+  crypto: cryptoEndpoints.length,
+  random: randomEndpoints.length,
+  math: mathEndpoints.length,
+  util: utilEndpoints.length,
+};


### PR DESCRIPTION
- Create endpoint-registry.ts with all 98 paid endpoint configs
- Rewrite _run_all_tests.ts with new features:
  - Single token mode (default) or all tokens (--all-tokens)
  - Category filtering (--category=stacks)
  - Name filtering (--filter=sha256)
  - 5-consecutive-failure bail-out
  - Clean progress output with per-token results
- Add X402_WORKER_URL env var for production testing
- Include test fixtures and validation helpers

Usage:
  bun run tests/_run_all_tests.ts              # STX only
  bun run tests/_run_all_tests.ts --all-tokens # All 3 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)