### PR TITLE
Add custom favicon for stx402.com

### DIFF
--- a/src/endpoints/favicon.ts
+++ b/src/endpoints/favicon.ts
@@ -1,0 +1,35 @@
+// Favicon for stx402.com
+// Design: Bitcoin orange (#f7931a) "402" badge with dark background
+
+const FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a1a"/>
+      <stop offset="100%" style="stop-color:#09090b"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#f7931a"/>
+      <stop offset="100%" style="stop-color:#ffb347"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="32" height="32" rx="6" fill="url(#bg)"/>
+  <!-- Border accent -->
+  <rect x="1" y="1" width="30" height="30" rx="5" fill="none" stroke="url(#accent)" stroke-width="1.5" opacity="0.8"/>
+  <!-- 402 text -->
+  <text x="16" y="21" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="url(#accent)" text-anchor="middle">402</text>
+  <!-- Small Bitcoin circle accent -->
+  <circle cx="16" cy="8" r="2.5" fill="url(#accent)" opacity="0.9"/>
+</svg>`;
+
+export function getFaviconSVG(): Response {
+  return new Response(FAVICON_SVG, {
+    headers: {
+      'Content-Type': 'image/svg+xml',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+}
+
+// Also export as data URI for embedding in HTML
+export const FAVICON_DATA_URI = `data:image/svg+xml,${encodeURIComponent(FAVICON_SVG)}`;

--- a/src/endpoints/scalarDocs.ts
+++ b/src/endpoints/scalarDocs.ts
@@ -13,7 +13,7 @@ export function getScalarHTML(specUrl: string): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>STX402 API</title>
   <meta name="description" content="X402 micropayment-gated API endpoints on Stacks">
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect fill='%23f7931a' rx='12' width='100' height='100'/><text x='50' y='68' font-size='40' font-weight='800' text-anchor='middle' fill='%23000'>402</text></svg>">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { fromHono } from "chanfana";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { getScalarHTML } from "./endpoints/scalarDocs";
+import { getFaviconSVG } from "./endpoints/favicon";
 
 // Health endpoints
 import { Health } from "./endpoints/health";
@@ -247,6 +248,10 @@ app.use(
 
 // Serve themed Scalar API docs at root (aibtc.com branding)
 app.get("/", (c) => c.html(getScalarHTML("/openapi.json")));
+
+// Serve favicon
+app.get("/favicon.svg", () => getFaviconSVG());
+app.get("/favicon.ico", () => getFaviconSVG()); // Browsers also request .ico
 
 // Setup OpenAPI registry (disable built-in Swagger UI, we use Scalar)
 const openapi = fromHono(app, {


### PR DESCRIPTION
## Summary

- Add new `/favicon.svg` route serving a custom Bitcoin orange 402 badge
- SVG design features dark gradient background with orange accents
- Updated `scalarDocs.ts` to reference `/favicon.svg` instead of inline data URI
- Also serves at `/favicon.ico` for browser compatibility

## Design

The favicon uses design elements from stx402.com:
- **Background**: Dark gradient (#09090b to #1a1a1a)
- **Accent**: Bitcoin orange gradient (#f7931a to #ffb347)
- **Text**: Bold "402" centered
- **Shape**: Rounded rectangle with subtle border glow

## Files Changed

- `src/endpoints/favicon.ts` - New file with SVG and route handler
- `src/endpoints/scalarDocs.ts` - Updated favicon link
- `src/index.ts` - Added favicon routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)