### PR TITLE
feat: add wallet intelligence endpoints

### DIFF
--- a/src/endpoints/walletAnalyze.ts
+++ b/src/endpoints/walletAnalyze.ts
@@ -1,0 +1,353 @@
+import { BaseEndpoint } from "./BaseEndpoint";
+import { getNameFromAddress } from "../utils/bns";
+import { getNetworkFromPrincipal } from "../utils/network";
+import { hiroFetch, getHiroApiUrl, isHiroRateLimitError } from "../utils/hiro";
+import type { AppContext } from "../types";
+
+// Known protocol contracts for DeFi detection
+const DEFI_PROTOCOLS: Record<string, { name: string; type: string }> = {
+  "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.alex": { name: "ALEX", type: "dex" },
+  "SP1Y5YSTAHZ88XYK1VPDH24GY0HPX5J4JECTMY4A1.velar": { name: "Velar", type: "dex" },
+  "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko": { name: "Arkadiko", type: "cdp" },
+  "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.stacking-dao": { name: "StackingDAO", type: "liquid-staking" },
+};
+
+// Blue-chip tokens on Stacks
+const BLUE_CHIP_TOKENS = [
+  "sbtc", "stx", "alex", "velar", "usda", "xusd", "ststx", "liststx",
+];
+
+// Known meme tokens
+const MEME_TOKENS = [
+  "welsh", "roo", "leo", "not", "pepe", "dog", "cat",
+];
+
+interface AccountBalance {
+  stx: {
+    balance: string;
+    total_sent: string;
+    total_received: string;
+    locked: string;
+  };
+  fungible_tokens: Record<string, { balance: string }>;
+  non_fungible_tokens: Record<string, { count: number }>;
+}
+
+interface TokenHolding {
+  contract: string;
+  name: string;
+  balance: string;
+  category: "blue-chip" | "meme" | "other";
+}
+
+interface StxPriceResponse {
+  stacks?: { usd?: number };
+}
+
+export class WalletAnalyze extends BaseEndpoint {
+  schema = {
+    tags: ["Wallet"],
+    summary: "(paid) Full wallet intelligence - USD values, risk score, DeFi detection, insights",
+    parameters: [
+      {
+        name: "address",
+        in: "path" as const,
+        required: true,
+        schema: { type: "string" as const },
+        description: "Stacks address to analyze",
+      },
+      {
+        name: "tokenType",
+        in: "query" as const,
+        required: false,
+        schema: {
+          type: "string" as const,
+          enum: ["STX", "sBTC", "USDCx"] as const,
+          default: "STX",
+        },
+      },
+    ],
+    responses: {
+      "200": {
+        description: "Wallet intelligence report",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              properties: {
+                address: { type: "string" as const },
+                network: { type: "string" as const },
+                bnsName: { type: "string" as const, nullable: true },
+                portfolio: {
+                  type: "object" as const,
+                  properties: {
+                    stxBalance: { type: "string" as const },
+                    stxUsdValue: { type: "number" as const },
+                    totalTokens: { type: "integer" as const },
+                    nftCount: { type: "integer" as const },
+                  },
+                },
+                holdings: {
+                  type: "array" as const,
+                  items: {
+                    type: "object" as const,
+                    properties: {
+                      contract: { type: "string" as const },
+                      name: { type: "string" as const },
+                      balance: { type: "string" as const },
+                      category: { type: "string" as const },
+                    },
+                  },
+                },
+                defiExposure: {
+                  type: "array" as const,
+                  items: {
+                    type: "object" as const,
+                    properties: {
+                      protocol: { type: "string" as const },
+                      type: { type: "string" as const },
+                    },
+                  },
+                },
+                riskScore: {
+                  type: "object" as const,
+                  properties: {
+                    score: { type: "integer" as const },
+                    level: { type: "string" as const },
+                    factors: {
+                      type: "object" as const,
+                      properties: {
+                        diversification: { type: "string" as const },
+                        memeExposure: { type: "string" as const },
+                        defiExposure: { type: "string" as const },
+                      },
+                    },
+                  },
+                },
+                insights: {
+                  type: "array" as const,
+                  items: { type: "string" as const },
+                },
+                tokenType: { type: "string" as const },
+              },
+            },
+          },
+        },
+      },
+      "400": { description: "Invalid address" },
+      "402": { description: "Payment required" },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const tokenType = this.getTokenType(c);
+    const address = c.req.param("address");
+
+    if (!address) {
+      return this.errorResponse(c, "address parameter is required", 400);
+    }
+
+    let network: "mainnet" | "testnet";
+    try {
+      network = getNetworkFromPrincipal(address) as "mainnet" | "testnet";
+    } catch {
+      return this.errorResponse(c, "Invalid Stacks address", 400);
+    }
+
+    const apiUrl = getHiroApiUrl(network);
+
+    try {
+      // Fetch all data in parallel
+      const [bnsName, balanceResponse, stxPriceResponse] = await Promise.all([
+        getNameFromAddress(address).catch(() => null),
+        hiroFetch(`${apiUrl}/extended/v1/address/${address}/balances`, {
+          headers: { Accept: "application/json" },
+        }),
+        fetch("https://api.coingecko.com/api/v3/simple/price?ids=stacks&vs_currencies=usd", {
+          headers: { Accept: "application/json" },
+        }).catch(() => null),
+      ]);
+
+      if (!balanceResponse.ok) {
+        return this.errorResponse(c, "Failed to fetch balances", 500);
+      }
+
+      const balanceData = (await balanceResponse.json()) as AccountBalance;
+
+      // Parse STX price
+      let stxPrice = 0;
+      if (stxPriceResponse?.ok) {
+        const priceData = (await stxPriceResponse.json()) as StxPriceResponse;
+        stxPrice = priceData.stacks?.usd || 0;
+      }
+
+      // Calculate STX values
+      const stxMicro = BigInt(balanceData.stx?.balance || "0");
+      const stxBalance = Number(stxMicro) / 1_000_000;
+      const stxUsdValue = stxBalance * stxPrice;
+
+      // Parse token holdings with categorization
+      const holdings: TokenHolding[] = [];
+      let memeCount = 0;
+      let blueChipCount = 0;
+
+      if (balanceData.fungible_tokens) {
+        for (const [contractId, data] of Object.entries(balanceData.fungible_tokens)) {
+          const [contract, assetName] = contractId.split("::");
+          const name = assetName || contract.split(".").pop() || "unknown";
+          const nameLower = name.toLowerCase();
+
+          let category: "blue-chip" | "meme" | "other" = "other";
+          if (BLUE_CHIP_TOKENS.some((t) => nameLower.includes(t))) {
+            category = "blue-chip";
+            blueChipCount++;
+          } else if (MEME_TOKENS.some((t) => nameLower.includes(t))) {
+            category = "meme";
+            memeCount++;
+          }
+
+          holdings.push({
+            contract,
+            name,
+            balance: data.balance,
+            category,
+          });
+        }
+      }
+
+      // Count NFTs
+      const nftCount = balanceData.non_fungible_tokens
+        ? Object.values(balanceData.non_fungible_tokens).reduce(
+            (sum, data) => sum + (data.count || 0),
+            0
+          )
+        : 0;
+
+      // Detect DeFi exposure
+      const defiExposure: { protocol: string; type: string }[] = [];
+      for (const holding of holdings) {
+        for (const [prefix, info] of Object.entries(DEFI_PROTOCOLS)) {
+          if (holding.contract.startsWith(prefix.split(".")[0])) {
+            if (!defiExposure.some((d) => d.protocol === info.name)) {
+              defiExposure.push({ protocol: info.name, type: info.type });
+            }
+          }
+        }
+      }
+
+      // Calculate risk score (0-100, lower is safer)
+      const totalTokens = holdings.length;
+      const memeRatio = totalTokens > 0 ? memeCount / totalTokens : 0;
+      const defiCount = defiExposure.length;
+
+      let riskScore = 20; // Base score
+
+      // Diversification factor
+      if (totalTokens === 0) {
+        riskScore += 0; // STX only = low risk
+      } else if (totalTokens <= 3) {
+        riskScore += 10; // Concentrated
+      } else if (totalTokens <= 10) {
+        riskScore += 5; // Moderate diversification
+      }
+
+      // Meme exposure
+      if (memeRatio > 0.5) {
+        riskScore += 40; // High meme exposure
+      } else if (memeRatio > 0.2) {
+        riskScore += 20; // Moderate meme exposure
+      } else if (memeRatio > 0) {
+        riskScore += 10; // Low meme exposure
+      }
+
+      // DeFi complexity
+      if (defiCount >= 3) {
+        riskScore += 15; // Complex DeFi exposure
+      } else if (defiCount > 0) {
+        riskScore += 5; // Some DeFi exposure
+      }
+
+      riskScore = Math.min(100, riskScore);
+
+      const riskLevel =
+        riskScore >= 70 ? "high" : riskScore >= 40 ? "moderate" : "low";
+
+      const riskFactors = {
+        diversification:
+          totalTokens === 0
+            ? "stx-only"
+            : totalTokens <= 3
+            ? "concentrated"
+            : "diversified",
+        memeExposure:
+          memeRatio > 0.5 ? "high" : memeRatio > 0 ? "moderate" : "none",
+        defiExposure:
+          defiCount >= 3 ? "complex" : defiCount > 0 ? "moderate" : "none",
+      };
+
+      // Generate insights
+      const insights: string[] = [];
+
+      if (stxBalance < 1) {
+        insights.push("Low STX balance - may not have enough for transaction fees");
+      }
+
+      if (memeRatio > 0.5) {
+        insights.push("Portfolio heavily weighted toward meme tokens - consider diversifying");
+      }
+
+      if (blueChipCount === 0 && totalTokens > 0) {
+        insights.push("No blue-chip tokens detected - consider adding established assets");
+      }
+
+      if (defiCount > 0) {
+        insights.push(
+          `Active in ${defiCount} DeFi protocol${defiCount > 1 ? "s" : ""}: ${defiExposure.map((d) => d.protocol).join(", ")}`
+        );
+      }
+
+      if (nftCount > 10) {
+        insights.push(`NFT collector with ${nftCount} items across collections`);
+      }
+
+      if (insights.length === 0) {
+        insights.push("Balanced portfolio with standard risk profile");
+      }
+
+      return c.json({
+        address,
+        network,
+        bnsName,
+        portfolio: {
+          stxBalance: stxBalance.toFixed(6),
+          stxUsdValue: Math.round(stxUsdValue * 100) / 100,
+          totalTokens,
+          nftCount,
+        },
+        holdings: holdings.slice(0, 20), // Top 20 holdings
+        defiExposure,
+        riskScore: {
+          score: riskScore,
+          level: riskLevel,
+          factors: riskFactors,
+        },
+        insights,
+        tokenType,
+      });
+    } catch (error) {
+      if (isHiroRateLimitError(error)) {
+        c.header("Retry-After", String(error.rateLimitError.retryAfter));
+        return c.json(
+          {
+            error: error.rateLimitError.error,
+            code: error.rateLimitError.code,
+            retryAfter: error.rateLimitError.retryAfter,
+            tokenType,
+          },
+          503
+        );
+      }
+      return this.errorResponse(c, `Failed to analyze wallet: ${String(error)}`, 500);
+    }
+  }
+}

--- a/src/endpoints/walletQuick.ts
+++ b/src/endpoints/walletQuick.ts
@@ -1,0 +1,197 @@
+import { BaseEndpoint } from "./BaseEndpoint";
+import { getNameFromAddress } from "../utils/bns";
+import { getNetworkFromPrincipal } from "../utils/network";
+import { hiroFetch, getHiroApiUrl, isHiroRateLimitError } from "../utils/hiro";
+import type { AppContext } from "../types";
+
+interface AccountBalance {
+  stx: {
+    balance: string;
+    locked: string;
+  };
+  fungible_tokens: Record<string, { balance: string }>;
+  non_fungible_tokens: Record<string, { count: number }>;
+}
+
+interface StxPriceResponse {
+  stacks?: { usd?: number };
+}
+
+export class WalletQuick extends BaseEndpoint {
+  schema = {
+    tags: ["Wallet"],
+    summary: "(paid) Fast portfolio summary - STX value, top holdings, BNS",
+    parameters: [
+      {
+        name: "address",
+        in: "path" as const,
+        required: true,
+        schema: { type: "string" as const },
+        description: "Stacks address",
+      },
+      {
+        name: "tokenType",
+        in: "query" as const,
+        required: false,
+        schema: {
+          type: "string" as const,
+          enum: ["STX", "sBTC", "USDCx"] as const,
+          default: "STX",
+        },
+      },
+    ],
+    responses: {
+      "200": {
+        description: "Quick portfolio summary",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              properties: {
+                address: { type: "string" as const },
+                bnsName: { type: "string" as const, nullable: true },
+                stx: {
+                  type: "object" as const,
+                  properties: {
+                    balance: { type: "string" as const },
+                    usdValue: { type: "number" as const },
+                    locked: { type: "string" as const },
+                  },
+                },
+                topHoldings: {
+                  type: "array" as const,
+                  items: {
+                    type: "object" as const,
+                    properties: {
+                      name: { type: "string" as const },
+                      balance: { type: "string" as const },
+                    },
+                  },
+                },
+                counts: {
+                  type: "object" as const,
+                  properties: {
+                    tokens: { type: "integer" as const },
+                    nfts: { type: "integer" as const },
+                  },
+                },
+                tokenType: { type: "string" as const },
+              },
+            },
+          },
+        },
+      },
+      "400": { description: "Invalid address" },
+      "402": { description: "Payment required" },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const tokenType = this.getTokenType(c);
+    const address = c.req.param("address");
+
+    if (!address) {
+      return this.errorResponse(c, "address parameter is required", 400);
+    }
+
+    let network: "mainnet" | "testnet";
+    try {
+      network = getNetworkFromPrincipal(address) as "mainnet" | "testnet";
+    } catch {
+      return this.errorResponse(c, "Invalid Stacks address", 400);
+    }
+
+    const apiUrl = getHiroApiUrl(network);
+
+    try {
+      // Fetch all data in parallel
+      const [bnsName, balanceResponse, stxPriceResponse] = await Promise.all([
+        getNameFromAddress(address).catch(() => null),
+        hiroFetch(`${apiUrl}/extended/v1/address/${address}/balances`, {
+          headers: { Accept: "application/json" },
+        }),
+        fetch("https://api.coingecko.com/api/v3/simple/price?ids=stacks&vs_currencies=usd", {
+          headers: { Accept: "application/json" },
+        }).catch(() => null),
+      ]);
+
+      if (!balanceResponse.ok) {
+        return this.errorResponse(c, "Failed to fetch balances", 500);
+      }
+
+      const balanceData = (await balanceResponse.json()) as AccountBalance;
+
+      // Parse STX price
+      let stxPrice = 0;
+      if (stxPriceResponse?.ok) {
+        const priceData = (await stxPriceResponse.json()) as StxPriceResponse;
+        stxPrice = priceData.stacks?.usd || 0;
+      }
+
+      // Calculate STX values
+      const stxMicro = BigInt(balanceData.stx?.balance || "0");
+      const stxBalance = Number(stxMicro) / 1_000_000;
+      const stxUsdValue = stxBalance * stxPrice;
+      const stxLocked = BigInt(balanceData.stx?.locked || "0");
+
+      // Get top 5 holdings by balance (simple heuristic - highest raw balance)
+      const topHoldings: { name: string; balance: string }[] = [];
+      if (balanceData.fungible_tokens) {
+        const sorted = Object.entries(balanceData.fungible_tokens)
+          .map(([contractId, data]) => {
+            const [, assetName] = contractId.split("::");
+            const name = assetName || contractId.split(".").pop() || "unknown";
+            return { name, balance: data.balance, balanceNum: BigInt(data.balance) };
+          })
+          .sort((a, b) => (b.balanceNum > a.balanceNum ? 1 : -1))
+          .slice(0, 5);
+
+        for (const h of sorted) {
+          topHoldings.push({ name: h.name, balance: h.balance });
+        }
+      }
+
+      // Count NFTs
+      const nftCount = balanceData.non_fungible_tokens
+        ? Object.values(balanceData.non_fungible_tokens).reduce(
+            (sum, data) => sum + (data.count || 0),
+            0
+          )
+        : 0;
+
+      const tokenCount = balanceData.fungible_tokens
+        ? Object.keys(balanceData.fungible_tokens).length
+        : 0;
+
+      return c.json({
+        address,
+        bnsName,
+        stx: {
+          balance: stxBalance.toFixed(6),
+          usdValue: Math.round(stxUsdValue * 100) / 100,
+          locked: (Number(stxLocked) / 1_000_000).toFixed(6),
+        },
+        topHoldings,
+        counts: {
+          tokens: tokenCount,
+          nfts: nftCount,
+        },
+        tokenType,
+      });
+    } catch (error) {
+      if (isHiroRateLimitError(error)) {
+        c.header("Retry-After", String(error.rateLimitError.retryAfter));
+        return c.json(
+          {
+            error: error.rateLimitError.error,
+            code: error.rateLimitError.code,
+            retryAfter: error.rateLimitError.retryAfter,
+            tokenType,
+          },
+          503
+        );
+      }
+      return this.errorResponse(c, `Failed to fetch wallet: ${String(error)}`, 500);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ import { StacksDecodeTx } from "./endpoints/stacksDecodeTx";
 import { StacksProfile } from "./endpoints/stacksProfile";
 import { StacksContractInfo } from "./endpoints/stacksContractInfo";
 
+// Wallet endpoints (intelligence layer on top of raw data)
+import { WalletAnalyze } from "./endpoints/walletAnalyze";
+import { WalletQuick } from "./endpoints/walletQuick";
+
 // AI endpoints
 import { DadJoke } from "./endpoints/dadJoke";
 import { ImageDescribe } from "./endpoints/imageDescribe";
@@ -208,6 +212,10 @@ openapi.post("/api/stacks/from-consensus-buff", paymentMiddleware, trackMetrics,
 openapi.post("/api/stacks/decode-tx", paymentMiddleware, trackMetrics, StacksDecodeTx as any);
 openapi.get("/api/stacks/profile/:address", paymentMiddleware, trackMetrics, StacksProfile as any);
 openapi.get("/api/stacks/contract-info/:contract_id", paymentMiddleware, trackMetrics, StacksContractInfo as any);
+
+// Wallet endpoints (paid) - intelligence layer
+openapi.get("/api/wallet/analyze/:address", paymentMiddleware, trackMetrics, WalletAnalyze as any);
+openapi.get("/api/wallet/quick/:address", paymentMiddleware, trackMetrics, WalletQuick as any);
 
 // AI endpoints (paid)
 openapi.get("/api/ai/dad-joke", paymentMiddleware, trackMetrics, DadJoke as any);

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -66,6 +66,10 @@ export const ENDPOINT_TIERS: Record<string, PricingTier> = {
   "/api/stacks/profile": "ai", // Multiple API calls
   "/api/stacks/contract-info": "simple", // Cacheable
 
+  // === WALLET ENDPOINTS (2) ===
+  "/api/wallet/analyze": "ai", // Multiple API calls + intelligence
+  "/api/wallet/quick": "simple", // Fast summary
+
   // === AI ENDPOINTS (13) ===
   "/api/ai/dad-joke": "ai",
   "/api/ai/summarize": "ai",


### PR DESCRIPTION
## Summary

This PR adds two wallet intelligence endpoints that provide an **intelligence layer** on top of the existing `/api/stacks/profile` endpoint.

**Why this adds value vs existing endpoints:**
- `stacksProfile` returns raw balances and counts
- These endpoints add USD values, risk assessment, categorization, and insights

## Endpoints

### `/api/wallet/analyze/:address` (ai tier - 0.003 STX)

Full wallet intelligence report:
- **USD Values**: STX balance with real-time USD value via CoinGecko
- **Token Categorization**: Holdings classified as blue-chip, meme, or other
- **DeFi Detection**: Identifies exposure to ALEX, Velar, Arkadiko, StackingDAO
- **Risk Scoring**: 0-100 score with level (low/moderate/high) and factors
- **Insights**: Actionable recommendations based on portfolio composition

### `/api/wallet/quick/:address` (simple tier - 0.001 STX)

Fast portfolio summary:
- STX balance with USD value
- Top 5 token holdings
- Token and NFT counts
- BNS name resolution

## Example Response (analyze)

```json
{
  "address": "SP...",
  "network": "mainnet",
  "bnsName": "example.btc",
  "portfolio": {
    "stxBalance": "1000.000000",
    "stxUsdValue": 1850.00,
    "totalTokens": 5,
    "nftCount": 12
  },
  "holdings": [
    { "contract": "SP...", "name": "sbtc-token", "balance": "100000000", "category": "blue-chip" },
    { "contract": "SP...", "name": "welsh", "balance": "1000000", "category": "meme" }
  ],
  "defiExposure": [
    { "protocol": "ALEX", "type": "dex" }
  ],
  "riskScore": {
    "score": 35,
    "level": "low",
    "factors": {
      "diversification": "diversified",
      "memeExposure": "moderate",
      "defiExposure": "moderate"
    }
  },
  "insights": [
    "Active in 1 DeFi protocol: ALEX",
    "NFT collector with 12 items across collections"
  ]
}
```

## Files Changed

- `src/endpoints/walletAnalyze.ts` - Full intelligence endpoint
- `src/endpoints/walletQuick.ts` - Fast summary endpoint
- `src/index.ts` - Route registration
- `src/utils/pricing.ts` - Pricing tiers

## Addresses PR #16 Feedback

- Focused, single-purpose PR (wallet only)
- No favicon changes
- Rebased on latest master
- Clear differentiation from existing stacksProfile endpoint

## Test Plan

- [ ] Test with mainnet address with diverse holdings
- [ ] Test with testnet address
- [ ] Test with BNS-named address
- [ ] Verify CoinGecko price fetch works (with fallback)
- [ ] Verify 402 payment flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)