### PR TITLE
ci: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node


### PR DESCRIPTION
## Summary

- Adds release-please GitHub Action workflow for automated releases
- Triggers on pushes to master branch
- Uses `node` release type to automatically bump `package.json` version

## How It Works

1. Merge PRs with conventional commits (`feat:`, `fix:`, etc.)
2. Release-please creates/updates a "Release PR" automatically
3. Merge the Release PR when ready to ship
4. Action bumps version, generates CHANGELOG.md, creates GitHub Release

## Required Setup

After merging, enable this in repo settings:
**Settings → Actions → General → Workflow permissions**
- Check: "Allow GitHub Actions to create and approve pull requests"

🤖 Generated with [Claude Code](https://claude.com/claude-code)