### PR TITLE
fix: update facilitator URL to new domain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,7 +42,7 @@
     }
   ],
   "vars": {
-    "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+    "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
     "X402_NETWORK": "mainnet", // "testnet"
     "X402_SERVER_ADDRESS": "SP31JEZWX4S131326VKM05QKJ0TDGNVVE0CDWWVA2" // "ST31JEZWX4S131326VKM05QKJ0TDGNVVE0DGNM4BP"
   },
@@ -75,7 +75,7 @@
         }
       ],
       "vars": {
-        "X402_FACILITATOR_URL": "https://facilitator.x402stacks.xyz",
+        "X402_FACILITATOR_URL": "https://facilitator.stacksx402.com",
         "X402_NETWORK": "testnet",
         "X402_SERVER_ADDRESS": "ST31JEZWX4S131326VKM05QKJ0TDGNVVE0DGNM4BP"
       },


### PR DESCRIPTION
## Summary

- Update facilitator URL from `facilitator.x402stacks.xyz` to `facilitator.stacksx402.com`
- Affects both production and staging environments

The old domain was deprecated when the infrastructure was migrated.

## Test plan

- [ ] Verify staging deployment connects to facilitator successfully
- [ ] Verify production deployment connects to facilitator successfully

🤖 Generated with [Claude Code](https://claude.ai/code)